### PR TITLE
Fix direct file access on Wasm

### DIFF
--- a/crates/blenvy/src/blueprints/mod.rs
+++ b/crates/blenvy/src/blueprints/mod.rs
@@ -119,6 +119,7 @@ impl Plugin for BlueprintsPlugin {
             .add_systems(
                 Update,
                 (
+                    load_raw_gltf,
                     blueprints_prepare_spawn,
                     blueprints_check_assets_loading,
                     blueprints_assets_loaded,

--- a/crates/blenvy/src/blueprints/mod.rs
+++ b/crates/blenvy/src/blueprints/mod.rs
@@ -49,15 +49,13 @@ impl Default for BluePrintBundle {
 
 #[derive(Debug, Clone)]
 /// Plugin for gltf blueprints
-pub struct BlueprintsPlugin {
-}
+pub struct BlueprintsPlugin {}
 
 impl Default for BlueprintsPlugin {
     fn default() -> Self {
-        Self { }
+        Self {}
     }
 }
-
 
 fn hot_reload(watching_for_changes: Res<WatchingForChanges>) -> bool {
     // println!("hot reload ? {}", watching_for_changes.0);
@@ -110,6 +108,8 @@ impl Plugin for BlueprintsPlugin {
             .register_type::<Vec<String>>()
             .register_type::<BlueprintAssets>()
             .register_type::<HashMap<String, Vec<String>>>()
+            .init_asset::<RawGltfAsset>()
+            .init_asset_loader::<RawGltfAssetLoader>()
             .configure_sets(
                 Update,
                 (GltfBlueprintsSet::Spawn, GltfBlueprintsSet::AfterSpawn)
@@ -132,16 +132,14 @@ impl Plugin for BlueprintsPlugin {
                     .chain()
                     .in_set(GltfBlueprintsSet::Spawn),
             )
-
             // animation
             .add_systems(
                 Update,
                 (
                     trigger_blueprint_animation_markers_events,
-                    trigger_instance_animation_markers_events
+                    trigger_instance_animation_markers_events,
                 ),
             )
-            
             // hot reload
             .add_systems(Update, react_to_asset_changes.run_if(hot_reload));
     }

--- a/crates/blenvy/src/blueprints/spawn_from_blueprints.rs
+++ b/crates/blenvy/src/blueprints/spawn_from_blueprints.rs
@@ -147,7 +147,7 @@ impl AssetLoader for RawGltfAssetLoader {
 
 #[derive(Debug, Component, Deref, DerefMut)]
 #[component(storage = "SparseSet")]
-struct AssociatedRawGltfHandle(Handle<RawGltfAsset>);
+pub(super) struct AssociatedRawGltfHandle(Handle<RawGltfAsset>);
 
 pub(super) fn load_raw_gltf(
     blueprint_instances_to_spawn: Query<(Entity, &BlueprintInfo), Added<SpawnBlueprint>>,

--- a/crates/blenvy/src/blueprints/spawn_from_blueprints.rs
+++ b/crates/blenvy/src/blueprints/spawn_from_blueprints.rs
@@ -197,10 +197,8 @@ pub(crate) fn blueprints_prepare_spawn(
         // and we also add all its assets
         /* prefetch attempt */
         let Some(RawGltfAsset(gltf)) = raw_gltf_assets.get(&raw_gltf_handle.0) else {
-            info!("heck");
             continue;
         };
-        info!("yay");
         for scene in gltf.scenes() {
             if let Some(scene_extras) = scene.extras().clone() {
                 let lookup: HashMap<String, Value> =

--- a/crates/blenvy/src/blueprints/spawn_from_blueprints.rs
+++ b/crates/blenvy/src/blueprints/spawn_from_blueprints.rs
@@ -125,7 +125,7 @@ Overview of the Blueprint Spawning process
 pub struct RawGltfAsset(pub RawGltf);
 
 #[derive(Default)]
-pub struct RawGltfAssetLoader;
+pub(super) struct RawGltfAssetLoader;
 
 impl AssetLoader for RawGltfAssetLoader {
     type Asset = RawGltfAsset;
@@ -146,7 +146,8 @@ impl AssetLoader for RawGltfAssetLoader {
 }
 
 #[derive(Debug, Component, Deref, DerefMut)]
-pub struct AssociatedRawGltfHandle(pub Handle<RawGltfAsset>);
+#[component(storage = "SparseSet")]
+struct AssociatedRawGltfHandle(Handle<RawGltfAsset>);
 
 pub(crate) fn load_raw_gltf(
     blueprint_instances_to_spawn: Query<(Entity, &BlueprintInfo), Added<SpawnBlueprint>>,

--- a/crates/blenvy/src/blueprints/spawn_from_blueprints.rs
+++ b/crates/blenvy/src/blueprints/spawn_from_blueprints.rs
@@ -149,7 +149,7 @@ impl AssetLoader for RawGltfAssetLoader {
 #[component(storage = "SparseSet")]
 struct AssociatedRawGltfHandle(Handle<RawGltfAsset>);
 
-pub(crate) fn load_raw_gltf(
+pub(super) fn load_raw_gltf(
     blueprint_instances_to_spawn: Query<(Entity, &BlueprintInfo), Added<SpawnBlueprint>>,
     asset_server: Res<AssetServer>,
     mut commands: Commands,
@@ -162,7 +162,7 @@ pub(crate) fn load_raw_gltf(
     }
 }
 
-pub(crate) fn blueprints_prepare_spawn(
+pub(super) fn blueprints_prepare_spawn(
     blueprint_instances_to_spawn: Query<(Entity, &BlueprintInfo, &AssociatedRawGltfHandle)>,
     mut commands: Commands,
     asset_server: Res<AssetServer>,


### PR DESCRIPTION
Notes:
- Makes `RawGltfAsset` `pub` so that a user could in theory preload it, but that's super ugly.
- Restricts some access modifiers while we're on it
- Runs `cargo fmt`
- Uses `from_slice_without_validation` and not `from_reader_without_validation` because our reader is `async` only, which does not implement the general `Reader` trait.

Future work:
- Improve preloading story (not sure how?)
- Only parse relevant parts of gltf
- Run `blueprints_prepare_spawn` only on `AssetEvent::LoadedWithDependencies`