### PR TITLE
Disable ExportRegistryPlugin on WASM

### DIFF
--- a/crates/blenvy/src/lib.rs
+++ b/crates/blenvy/src/lib.rs
@@ -60,6 +60,7 @@ impl Plugin for BlenvyPlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins((
             ComponentsFromGltfPlugin::default(),
+            #[cfg(not(target_arch = "wasm32"))]
             ExportRegistryPlugin::default(),
             BlueprintsPlugin::default(),
         ))


### PR DESCRIPTION
Because it tries to write "registry.json" to the assets directory which fails on a web build.