### PR TITLE
warn instead of crash when components aren't reflectable

### DIFF
--- a/crates/blenvy/src/components/process_gltfs.rs
+++ b/crates/blenvy/src/components/process_gltfs.rs
@@ -8,7 +8,7 @@ use bevy::{
     },
     gltf::{GltfExtras, GltfMaterialExtras, GltfMeshExtras, GltfSceneExtras},
     hierarchy::Parent,
-    log::debug,
+    log::{debug, warn},
     reflect::{Reflect, TypeRegistration},
     utils::HashMap,
 };
@@ -145,10 +145,11 @@ pub fn add_components_from_gltf_extras(world: &mut World) {
 
             {
                 let mut entity_mut = world.entity_mut(entity);
-                type_registration
-                    .data::<ReflectComponent>()
-                    .expect("Unable to reflect component")
-                    .insert(&mut entity_mut, &*component, &type_registry);
+                let Some(reflected_component) = type_registration.data::<ReflectComponent>() else {
+                    warn!(?component, "unable to reflect component");
+                    continue;
+                };
+                reflected_component.insert(&mut entity_mut, &*component, &type_registry);
 
                 entity_mut.insert(GltfProcessed); //
             }

--- a/crates/blenvy/src/components/process_gltfs.rs
+++ b/crates/blenvy/src/components/process_gltfs.rs
@@ -147,6 +147,7 @@ pub fn add_components_from_gltf_extras(world: &mut World) {
                 let mut entity_mut = world.entity_mut(entity);
                 let Some(reflected_component) = type_registration.data::<ReflectComponent>() else {
                     warn!(?component, "unable to reflect component");
+                    entity_mut.insert(GltfProcessed);
                     continue;
                 };
                 reflected_component.insert(&mut entity_mut, &*component, &type_registry);


### PR DESCRIPTION
before

```
thread 'main' panicked at /Users/chris/github/kaosat-dev/Blenvy/crates/blenvy/src/components/process_gltfs.rs:150:22:
Unable to reflect component
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `blenvy::components::process_gltfs::add_components_from_gltf_extras`!
```

after

```
2024-07-28T23:39:54.344440Z  WARN blenvy::components::process_gltfs: unable to reflect component component=DynamicStruct(blenvy::blueprints::materials::MaterialInfo { name: "Material.002", path: "materials/test_scenes_materials.glb" })
2024-07-28T23:39:54.344497Z  WARN blenvy::components::process_gltfs: unable to reflect component component=DynamicStruct(blenvy::blueprints::materials::MaterialInfo { name: "Material.003", path: "materials/test_scenes_materials.glb" })
```