### PR TITLE
Remove CameraTracking component and a small documentation fix

### DIFF
--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -24,8 +24,7 @@ This guide assumes you use Blender 4.2 or newer and have set it to English.
     <summary>This window should show up</summary>
 
     <img src="img/install.png" width=50%>
-
-    </summary>
+  
     </details>
 - Leave all settings as is and click on `OK`
 
@@ -315,4 +314,4 @@ Okay, maybe not that much glory. But the important part is that the player is vi
 
 - Read the [Blenvy for Bevy](../../crates/blenvy/README.md) documentation for more features on the Bevy side.
 - Read the [Blenvy for Blender](../../tools/blenvy/README.md) documentation for more features on the Blender side.
-- Read about the [Avian Physics Integration](../avian/readme.md) to learn how to setup colliders in Blender that will be used by the Avian physics engine in Bevy.
+- Read about the [Avian Physics Integration](../avian/README.md) to learn how to setup colliders in Blender that will be used by the Avian physics engine in Bevy.

--- a/examples/demo/src/core/camera/camera_tracking.rs
+++ b/examples/demo/src/core/camera/camera_tracking.rs
@@ -1,20 +1,5 @@
 use bevy::prelude::*;
 
-#[derive(Component, Reflect, Debug)]
-#[reflect(Component)]
-/// Component for cameras, with an offset from the Trackable target  
-///
-pub struct CameraTracking {
-    pub offset: Vec3,
-}
-impl Default for CameraTracking {
-    fn default() -> Self {
-        CameraTracking {
-            offset: Vec3::new(0.0, 6.0, 8.0),
-        }
-    }
-}
-
 #[derive(Component, Reflect, Debug, Deref, DerefMut)]
 #[reflect(Component)]
 /// Component for cameras, with an offset from the Trackable target  

--- a/examples/demo/src/core/camera/mod.rs
+++ b/examples/demo/src/core/camera/mod.rs
@@ -11,7 +11,6 @@ pub struct CameraPlugin;
 impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<CameraTrackable>()
-            .register_type::<CameraTracking>()
             .register_type::<CameraTrackingOffset>()
             .register_type::<SSAOSettings>()
             .add_systems(

--- a/tools/blenvy/tests/expected_component_values.py
+++ b/tools/blenvy/tests/expected_component_values.py
@@ -97,8 +97,6 @@ expected_custom_property_values = {'bevy_animation::AnimationPlayer': '(animatio
  'blenvy::blender_settings::lighting::BlenderShadowSettings': '(cascade_size: 0)',
  'bevy_gltf_worlflow_examples_common::core::camera::camera_replace_proxies::SSAOSettings': '()',
  'bevy_gltf_worlflow_examples_common::core::camera::camera_tracking::CameraTrackable': '()',
- 'bevy_gltf_worlflow_examples_common::core::camera::camera_tracking::CameraTracking': '(offset: Vec3(x:0.0, y:0.0, '
-                                                                                      'z:0.0))',
  'bevy_gltf_worlflow_examples_common::core::camera::camera_tracking::CameraTrackingOffset': '(Vec3(x:0.0, y:0.0, '
                                                                                             'z:0.0))',
  'bevy_gltf_worlflow_examples_common::game::picking::Pickable': '()',
@@ -359,10 +357,6 @@ expected_custom_property_values_randomized = {'bevy_animation::AnimationPlayer':
  'blenvy::blender_settings::lighting::BlenderShadowSettings': '(cascade_size: 73)',
  'bevy_gltf_worlflow_examples_common::core::camera::camera_replace_proxies::SSAOSettings': '()',
  'bevy_gltf_worlflow_examples_common::core::camera::camera_tracking::CameraTrackable': '()',
- 'bevy_gltf_worlflow_examples_common::core::camera::camera_tracking::CameraTracking': '(offset: '
-                                                                                      'Vec3(x:0.5714026093482971, '
-                                                                                      'y:0.42888906598091125, '
-                                                                                      'z:0.5780913233757019))',
  'bevy_gltf_worlflow_examples_common::core::camera::camera_tracking::CameraTrackingOffset': '(Vec3(x:0.5714026093482971, '
                                                                                             'y:0.42888906598091125, '
                                                                                             'z:0.5780913233757019))',


### PR DESCRIPTION
I noticed the CameraTracking component is not used in the examples, so I removed it.
I also found some documentation issues that I fixed in this PR.