### PR TITLE
Fix handling of `UVec2`, `UVec3` and `UVec4` as uint

### DIFF
--- a/tools/blenvy/add_ons/bevy_components/propGroups/conversions_from_prop_group.py
+++ b/tools/blenvy/add_ons/bevy_components/propGroups/conversions_from_prop_group.py
@@ -10,15 +10,15 @@ conversion_tables = {
 
     "glam::Vec2": lambda value: "Vec2(x:"+str(value[0])+ ", y:"+str(value[1])+")",
     "glam::DVec2": lambda value: "DVec2(x:"+str(value[0])+ ", y:"+str(value[1])+")",
-    "glam::UVec2": lambda value: "UVec2(x:"+str(value[0])+ ", y:"+str(value[1])+")",
+    "glam::UVec2": lambda value: "UVec2(x:"+str(int(value[0]))+ ", y:"+str(int(value[1]))+")",
 
     "glam::Vec3": lambda value: "Vec3(x:"+str(value[0])+ ", y:"+str(value[1])+ ", z:"+str(value[2])+")",
     "glam::Vec3A": lambda value: "Vec3A(x:"+str(value[0])+ ", y:"+str(value[1])+ ", z:"+str(value[2])+")",
-    "glam::UVec3": lambda value: "UVec3(x:"+str(value[0])+ ", y:"+str(value[1])+ ", z:"+str(value[2])+")",
+    "glam::UVec3": lambda value: "UVec3(x:"+str(int(value[0]))+ ", y:"+str(int(value[1]))+ ", z:"+str(int(value[2]))+")",
 
     "glam::Vec4": lambda value: "Vec4(x:"+str(value[0])+ ", y:"+str(value[1])+ ", z:"+str(value[2])+ ", w:"+str(value[3])+")",
     "glam::DVec4": lambda value: "DVec4(x:"+str(value[0])+ ", y:"+str(value[1])+ ", z:"+str(value[2])+ ", w:"+str(value[3])+")",
-    "glam::UVec4": lambda value: "UVec4(x:"+str(value[0])+ ", y:"+str(value[1])+ ", z:"+str(value[2])+ ", w:"+str(value[3])+")",
+    "glam::UVec4": lambda value: "UVec4(x:"+str(int(value[0]))+ ", y:"+str(int(value[1]))+ ", z:"+str(int(value[2]))+ ", w:"+str(int(value[3]))+")",
 
     "glam::Quat":  lambda value: "Quat(x:"+str(value[0])+ ", y:"+str(value[1])+ ", z:"+str(value[2])+ ", w:"+str(value[3])+")",
 

--- a/tools/blenvy/add_ons/bevy_components/registry/registry.py
+++ b/tools/blenvy/add_ons/bevy_components/registry/registry.py
@@ -65,17 +65,17 @@ class ComponentsRegistry(PropertyGroup):
 
         "glam::Vec2": {"type": FloatVectorProperty, "presets": dict(size = 2) },
         "glam::DVec2": {"type": FloatVectorProperty, "presets": dict(size = 2) },
-        "glam::UVec2": {"type": FloatVectorProperty, "presets": dict(size = 2) },
+        "glam::UVec2": {"type": IntVectorProperty, "presets": {"size": 2, "min": 0} },
 
         "glam::Vec3": {"type": FloatVectorProperty, "presets": {"size":3} },
         "glam::Vec3A":{"type": FloatVectorProperty, "presets": {"size":3} },
         "glam::DVec3":{"type": FloatVectorProperty, "presets": {"size":3} },
-        "glam::UVec3":{"type": FloatVectorProperty, "presets": {"size":3} },
+        "glam::UVec3":{"type": IntVectorProperty, "presets": {"size":3, "min":0} },
 
         "glam::Vec4": {"type": FloatVectorProperty, "presets": {"size":4} },
         "glam::Vec4A": {"type": FloatVectorProperty, "presets": {"size":4} },
         "glam::DVec4": {"type": FloatVectorProperty, "presets": {"size":4} },
-        "glam::UVec4":{"type": FloatVectorProperty, "presets": {"size":4, "min":0.0} },
+        "glam::UVec4":{"type": IntVectorProperty, "presets": {"size":4, "min":0} },
 
         "glam::Quat": {"type": FloatVectorProperty, "presets": {"size":4} },
 


### PR DESCRIPTION
Hey there 👋

Ron deserialization was failing for components using UVec types, because they were being mistakenly serialized as floats. This makes it so that they can be deserialized