### PR TITLE
Replace println! with debug!

### DIFF
--- a/crates/blenvy/src/blueprints/animation.rs
+++ b/crates/blenvy/src/blueprints/animation.rs
@@ -130,7 +130,7 @@ pub fn trigger_blueprint_animation_markers_events(
                             let frame_seconds = (animation_length_frames
                                 / animation_length_seconds)
                                 * time_in_animation;
-                            // println!("frame seconds {}", frame_seconds);
+                            // debug!("frame seconds {}", frame_seconds);
                             let frame = frame_seconds.ceil() as u32; // FIXME , bad hack
 
                             let matching_animation_marker = &animation_markers.0[animation_name];
@@ -138,7 +138,7 @@ pub fn trigger_blueprint_animation_markers_events(
                             if matching_animation_marker.contains_key(&frame) {
                                 let matching_markers_per_frame =
                                     matching_animation_marker.get(&frame).unwrap();
-                                println!(
+                                debug!(
                                     "FOUND A MARKER {:?} at frame {}",
                                     matching_markers_per_frame, frame
                                 );
@@ -191,7 +191,7 @@ pub fn trigger_instance_animation_markers_events(
                         animations.named_animations.get(animation_name)
                     {
                         if let Some(__animation_clip) = animation_clips.get(animation_clip_handle) {
-                            println!("found the animation clip");
+                            debug!("found the animation clip");
                         }
                     }
                 }
@@ -202,8 +202,8 @@ pub fn trigger_instance_animation_markers_events(
         // animation_player.play(animation)
 
         if animation_clip.is_some() {
-            // println!("Entity {:?} markers {:?}", entity, markers);
-            // println!("Player {:?} {}", animation_player.elapsed(), animation_player.completions());
+            // debug!("Entity {:?} markers {:?}", entity, markers);
+            // debug!("Player {:?} {}", animation_player.elapsed(), animation_player.completions());
             // FIMXE: yikes ! very inneficient ! perhaps add boilerplate to the "start playing animation" code so we know what is playing
             let animation_name = animations.named_animations.iter().find_map(|(key, value)| {
                 if value == animation_player.animation_clip() {
@@ -234,8 +234,8 @@ pub fn trigger_instance_animation_markers_events(
                     let matching_markers_per_frame = matching_animation_marker.get(&frame).unwrap();
 
                     // let timediff = animation_length_seconds - time_in_animation;
-                    // println!("timediff {}", timediff);
-                    // println!("FOUND A MARKER {:?} at frame {}", matching_markers_per_frame, frame);
+                    // debug!("timediff {}", timediff);
+                    // debug!("FOUND A MARKER {:?} at frame {}", matching_markers_per_frame, frame);
                     // emit an event AnimationMarkerReached(entity, animation_name, frame, marker_name)
                     // FIXME: problem, this can fire multiple times in a row, depending on animation length , speed , etc
                     for marker in matching_markers_per_frame {

--- a/crates/blenvy/src/blueprints/copy_components.rs
+++ b/crates/blenvy/src/blueprints/copy_components.rs
@@ -95,7 +95,7 @@ impl CopyComponents {
                 .get_entity_mut(self.destination)
                 .expect("destination entity should exist");
 
-            // println!("contains typeid {:?} {}", type_id, destination.contains_type_id(type_id));
+            // debug!("contains typeid {:?} {}", type_id, destination.contains_type_id(type_id));
             // we only want to copy components that are NOT already in the destination (ie no overwriting existing components)
             if !destination.contains_type_id(type_id) {
                 component.insert(&mut destination, &*source, &type_registry);

--- a/crates/blenvy/src/blueprints/hot_reload.rs
+++ b/crates/blenvy/src/blueprints/hot_reload.rs
@@ -34,10 +34,10 @@ pub(crate) fn react_to_asset_changes(
 
         if let AssetEvent::Modified { id } = event {
             // React to the gltf file being modified
-            // println!("Modified gltf {:?}", asset_server.get_path(*id));
+            // debug!("Modified gltf {:?}", asset_server.get_path(*id));
             if let Some(asset_path) = asset_server.get_path(*id) {
                 // let untyped = asset_server.get_handle_untyped(asset_path.clone());
-                // println!("matching untyped handle {:?}", untyped);
+                // debug!("matching untyped handle {:?}", untyped);
                 // let bla = untyped.unwrap().id();
                 // asset_server.get
                 // in order to avoid respawn both a parent & a child , which would crash Bevy, we do things in two steps
@@ -46,7 +46,7 @@ pub(crate) fn react_to_asset_changes(
                     .get(&asset_path.to_string())
                 {
                     for entity in entities.iter() {
-                        // println!("matching blueprint instance {}", entity);
+                        // debug!("matching blueprint instance {}", entity);
                         // disregard entities that are already (re) spawning
                         if !respawn_candidates.contains(&entity)
                             && blueprint_assets.get(*entity).is_ok()
@@ -78,9 +78,9 @@ pub(crate) fn react_to_asset_changes(
             retained_candidates.push(**entity);
         }
     }
-    // println!("respawn candidates {:?}", respawn_candidates);
+    // debug!("respawn candidates {:?}", respawn_candidates);
     for retained in retained_candidates.iter() {
-        // println!("retained {}", retained);
+        // debug!("retained {}", retained);
 
         if let Ok((entity, entity_name, _blueprint_info, children)) =
             blueprint_assets.get(*retained)
@@ -104,5 +104,5 @@ pub(crate) fn react_to_asset_changes(
         }
     }
 
-    // println!("done with asset updates");
+    // debug!("done with asset updates");
 }

--- a/crates/blenvy/src/blueprints/mod.rs
+++ b/crates/blenvy/src/blueprints/mod.rs
@@ -53,7 +53,7 @@ impl Default for BluePrintBundle {
 pub struct BlueprintsPlugin {}
 
 fn hot_reload(watching_for_changes: Res<WatchingForChanges>) -> bool {
-    // println!("hot reload ? {}", watching_for_changes.0);
+    // debug!("hot reload ? {}", watching_for_changes.0);
     watching_for_changes.0
 }
 

--- a/crates/blenvy/src/blueprints/spawn_from_blueprints.rs
+++ b/crates/blenvy/src/blueprints/spawn_from_blueprints.rs
@@ -244,7 +244,7 @@ pub(crate) fn blueprints_check_assets_metadata_files_loading(
         }
         let progress: f32 = loaded_amount as f32 / total as f32;
         assets_to_load.progress = progress;
-        // println!("LOADING: in progress for ALL assets of {:?} (instance of {}): {} ",entity_name, blueprint_info.path, progress * 100.0);
+        // debug!("LOADING: in progress for ALL assets of {:?} (instance of {}): {} ",entity_name, blueprint_info.path, progress * 100.0);
     }
 }
 
@@ -323,7 +323,7 @@ pub(super) fn blueprints_prepare_spawn(
                     if !assets_to_blueprint_instances.untyped_id_to_blueprint_entity_ids[&path_id]
                         .contains(&entity)
                     {
-                        // println!("adding mapping between {} and entity {:?}", path_id, all_names.get(entity));
+                        // debug!("adding mapping between {} and entity {:?}", path_id, all_names.get(entity));
                         assets_to_blueprint_instances
                             .untyped_id_to_blueprint_entity_ids
                             .get_mut(&path_id)
@@ -353,7 +353,7 @@ pub(super) fn blueprints_prepare_spawn(
                 [&blueprint_info.path]
                 .contains(&entity)
             {
-                // println!("adding mapping between {} and entity {:?}", path_id, all_names.get(entity));
+                // debug!("adding mapping between {} and entity {:?}", path_id, all_names.get(entity));
                 assets_to_blueprint_instances
                     .untyped_id_to_blueprint_entity_ids
                     .get_mut(&blueprint_info.path)
@@ -419,11 +419,11 @@ pub(crate) fn blueprints_check_assets_loading(
         }
         let progress: f32 = loaded_amount as f32 / total as f32;
         assets_to_load.progress = progress;
-        //println!("LOADING: in progress for ALL assets of {:?} (instance of {}): {} ",entity_name, blueprint_info.path, progress * 100.0);
+        //debug!("LOADING: in progress for ALL assets of {:?} (instance of {}): {} ",entity_name, blueprint_info.path, progress * 100.0);
 
         if all_loaded {
             assets_to_load.all_loaded = true;
-            // println!("LOADING: DONE for ALL assets of {:?} (instance of {}), preparing for spawn", entity_name, blueprint_info.path);
+            // debug!("LOADING: DONE for ALL assets of {:?} (instance of {}), preparing for spawn", entity_name, blueprint_info.path);
             blueprint_events.send(BlueprintEvent::AssetsLoaded {
                 entity,
                 blueprint_name: blueprint_info.name.clone(),
@@ -510,8 +510,8 @@ pub(crate) fn blueprints_assets_loaded(
         }
         let graph = graphs.add(graph);
 
-        //println!("Named animations : {:?}", named_animations.keys());
-        //println!("ANIMATION INFOS: {:?}", animation_infos);
+        //debug!("Named animations : {:?}", named_animations.keys());
+        //debug!("ANIMATION INFOS: {:?}", animation_infos);
 
         commands.entity(entity).insert((
             SceneBundle {
@@ -581,7 +581,7 @@ pub(crate) fn blueprints_scenes_spawned(
         if track_root.is_none() {
             for parent in all_parents.iter_ancestors(entity) {
                 if with_blueprint_infos.get(parent).is_ok() {
-                    println!(
+                    debug!(
                         "found a parent with blueprint_info {:?} for {:?}",
                         all_names.get(parent),
                         all_names.get(entity)
@@ -597,12 +597,12 @@ pub(crate) fn blueprints_scenes_spawned(
         if children.is_some() {
             for child in all_children.iter_descendants(entity) {
                 if with_blueprint_infos.get(child).is_ok() {
-                    // println!("Parent blueprint instance of {:?} is {:?}",  all_names.get(child), all_names.get(entity));
+                    // debug!("Parent blueprint instance of {:?} is {:?}",  all_names.get(child), all_names.get(entity));
                     for parent in all_parents.iter_ancestors(child) {
                         if with_blueprint_infos.get(parent).is_ok() {
                             if parent == entity {
-                                //println!("yohoho");
-                                /*println!(
+                                //debug!("yohoho");
+                                /*debug!(
                                     "Parent blueprint instance of {:?} is {:?}",
                                     all_names.get(child),
                                     all_names.get(parent)
@@ -727,7 +727,7 @@ pub(crate) fn blueprints_cleanup_spawned_scene(
         if animations.named_animations.keys().len() > 0 {
             for (entity_with_player, parent) in animation_players.iter() {
                 if parent.get() == blueprint_root_entity {
-                    println!(
+                    debug!(
                         "FOUND ANIMATION PLAYER FOR {:?} {:?} ",
                         all_names.get(original),
                         all_names.get(entity_with_player)
@@ -751,7 +751,7 @@ pub(crate) fn blueprints_cleanup_spawned_scene(
                 if with_animation_infos.get(child).is_ok() {
                     // player is already on the same entity as the animation_infos
                     if animation_players.get(child).is_ok() {
-                        println!(
+                        debug!(
                             "found BLUEPRINT animation player for {:?} at {:?} Root: {:?}",
                             all_names.get(child),
                             all_names.get(child),
@@ -764,13 +764,13 @@ pub(crate) fn blueprints_cleanup_spawned_scene(
                     } else {
                         for parent in all_parents.iter_ancestors(child) {
                             if animation_players.get(parent).is_ok() {
-                                /*println!(
+                                /*debug!(
                                     "found SCENE animation player for {:?} at {:?} Root: {:?}",
                                     all_names.get(child),
                                     all_names.get(parent),
                                     all_names.get(original)
                                 );
-                                println!("INSERTING SCENE ANIMATIONS INTO");*/
+                                debug!("INSERTING SCENE ANIMATIONS INTO");*/
                                 let original_animations = anims.get(original).unwrap();
                                 commands.entity(child).insert((
                                     InstanceAnimationPlayerLink(parent),
@@ -873,7 +873,7 @@ pub(crate) fn blueprints_finalize_instances(
                     }
                     if all_spawned {
                         // let root_name = all_names.get(track_root.0);
-                        // println!("ALLLLL SPAAAAWNED for {} named {:?}", track_root.0, root_name);
+                        // debug!("ALLLLL SPAAAAWNED for {} named {:?}", track_root.0, root_name);
                         commands.entity(track_root.0).insert(BlueprintChildrenReady);
                     }
                 }

--- a/crates/blenvy/src/components/blender_settings/lighting.rs
+++ b/crates/blenvy/src/components/blender_settings/lighting.rs
@@ -130,15 +130,15 @@ fn process_tonemapping(
         for (scene_id, tone_mapping) in tonemappings.iter() {
             match tone_mapping {
                 BlenderToneMapping::None => {
-                    //println!("TONEMAPPING NONE");
+                    //debug!("TONEMAPPING NONE");
                     commands.entity(entity).remove::<Tonemapping>();
                 }
                 BlenderToneMapping::AgX => {
-                    //println!("TONEMAPPING Agx");
+                    //debug!("TONEMAPPING Agx");
                     commands.entity(entity).insert(Tonemapping::AgX);
                 }
                 BlenderToneMapping::Filmic => {
-                    //println!("TONEMAPPING Filmic");
+                    //debug!("TONEMAPPING Filmic");
                     commands.entity(entity).insert(Tonemapping::BlenderFilmic);
                 }
             }

--- a/crates/blenvy/src/components/ronstring_to_reflect_component.rs
+++ b/crates/blenvy/src/components/ronstring_to_reflect_component.rs
@@ -13,7 +13,7 @@ pub fn ronstring_to_reflect_component(
 ) -> Vec<(Box<dyn Reflect>, TypeRegistration)> {
     let lookup: HashMap<String, Value> = ron::from_str(ron_string).unwrap();
     let mut components: Vec<(Box<dyn Reflect>, TypeRegistration)> = Vec::new();
-    // println!("ron_string {:?}", ron_string);
+    // debug!("ron_string {:?}", ron_string);
     for (name, value) in lookup.into_iter() {
         let parsed_value: String = match value.clone() {
             Value::String(str) => str,
@@ -63,7 +63,7 @@ fn components_string_to_components(
         let serializer = ReflectSerializer::new(&test_struct, &type_registry);
         let serialized =
             ron::ser::to_string_pretty(&serializer, ron::ser::PrettyConfig::default()).unwrap();
-        println!("serialized Component {}", serialized);
+        debug!("serialized Component {}", serialized);
         */
         debug!("component data ron string {}", ron_string);
         let mut deserializer = ron::Deserializer::from_str(ron_string.as_str())

--- a/crates/blenvy/src/save_load/common.rs
+++ b/crates/blenvy/src/save_load/common.rs
@@ -9,7 +9,7 @@ pub(crate) fn spawn_from_blueprintworld(
     mut commands: Commands,
 ) {
     for (__entity, blueprint_world) in added_blueprint_worlds.iter() {
-        println!("added blueprintWorld {:?}", blueprint_world);
+        debug!("added blueprintWorld {:?}", blueprint_world);
 
         // here we spawn the static part our game world/level, which is also a blueprint !
         let __static_world = commands

--- a/crates/blenvy/src/save_load/saving.rs
+++ b/crates/blenvy/src/save_load/saving.rs
@@ -56,7 +56,7 @@ pub(crate) fn prepare_save_game(
     }
 
     for (entity, parent, children) in dynamic_entities.iter() {
-        println!("prepare save game for entity");
+        debug!("prepare save game for entity");
         let parent = parent.get();
         if root_entities.contains(parent) {
             commands.entity(entity).insert(RootEntity);

--- a/examples/animation/src/main.rs
+++ b/examples/animation/src/main.rs
@@ -64,11 +64,11 @@ pub fn animation_control(
 ) {
     // robots
     if keycode.just_pressed(KeyCode::KeyB) {
-        println!("scan animation for robots");
+        debug!("scan animation for robots");
         for (link, animations) in animated_robots.iter() {
             let (mut animation_player, mut animation_transitions) =
                 animation_players.get_mut(link.0).unwrap();
-            println!("got some animations");
+            debug!("got some animations");
             let anim_name = "Scan";
             animation_transitions
                 .play(

--- a/examples/demo/src/game/level_transitions.rs
+++ b/examples/demo/src/game/level_transitions.rs
@@ -33,7 +33,7 @@ pub fn trigger_level_transition(
                     || level_transition_triggers.get(entity1_parent.get()).is_ok()
                     || level_transition_triggers.get(entity2_parent.get()).is_ok()
                 {
-                    println!("collision started, we can transition to level");
+                    debug!("collision started, we can transition to level");
                     let transition_trigger;
                     if level_transition_triggers.get(*entity1).is_ok() {
                         transition_trigger = level_transition_triggers.get(*entity1).unwrap();
@@ -52,7 +52,7 @@ pub fn trigger_level_transition(
                         || players.get(*entity2).is_ok()
                         || players.get(entity2_parent.get()).is_ok()
                     {
-                        println!("one entity is the player, we can enter")
+                        debug!("one entity is the player, we can enter")
                     } else {
                         // if none of our entities is a player, bail out, as only entities with player components should trigger a transition
                         return;
@@ -66,7 +66,7 @@ pub fn trigger_level_transition(
 
                     let target_level = &transition_trigger.target;
                     let level: Handle<Gltf>;
-                    println!("target level {}", target_level);
+                    debug!("target level {}", target_level);
                     if target_level == "Level1" {
                         level = game_assets.level1.clone().unwrap();
                     } else if target_level == "Level2" {
@@ -92,7 +92,7 @@ pub fn trigger_level_transition(
                 }
             }
             CollisionEvent::Stopped(_entity1, _entity2, _) => {
-                // println!("collision ended")
+                // debug!("collision ended")
             }
         }
     }

--- a/examples/save_load/src/main.rs
+++ b/examples/save_load/src/main.rs
@@ -84,7 +84,7 @@ fn spawn_blueprint_instance(keycode: Res<ButtonInput<KeyCode>>, mut commands: Co
 
 fn move_movers(mut movers: Query<&mut Transform, With<Dynamic>>) {
     for mut transform in movers.iter_mut() {
-        // println!("moving dynamic entity");
+        // debug!("moving dynamic entity");
         transform.translation.x += 0.005;
     }
 }

--- a/testing/bevy_example/src/game/animation.rs
+++ b/testing/bevy_example/src/game/animation.rs
@@ -48,7 +48,7 @@ pub fn animations(
     parents: Query<&Parent>,
 ) {
     for (entity, name, animation_infos) in added_animation_infos.iter() {
-        //println!("animated stuf {:?} on entity {}", animation_infos, name);
+        //debug!("animated stuf {:?} on entity {}", animation_infos, name);
         let gltf = assets_gltf.get(&animtest.0).unwrap();
         let mut matching_data = true;
         for animation_info in &animation_infos.animations {
@@ -58,17 +58,17 @@ pub fn animations(
             }
         }
         if matching_data {
-            println!(
+            debug!(
                 "inserting Animations components into {} ({:?})",
                 name, entity
             );
-            println!("Found match {:?}", gltf.named_animations);
+            debug!("Found match {:?}", gltf.named_animations);
             commands.entity(entity).insert(InstanceAnimations {
                 named_animations: gltf.named_animations.clone(),
             });
             for ancestor in parents.iter_ancestors(entity) {
                 if added_animation_players.contains(ancestor) {
-                    // println!("found match with animationPlayer !! {:?}",names.get(ancestor));
+                    // debug!("found match with animationPlayer !! {:?}",names.get(ancestor));
                     commands
                         .entity(entity)
                         .insert(InstanceAnimationPlayerLink(ancestor));
@@ -113,11 +113,11 @@ pub fn play_animations(
     keycode: Res<ButtonInput<KeyCode>>,
 ) {
     if keycode.just_pressed(KeyCode::KeyQ) {
-        println!("playing fox blueprint animation requested");
+        debug!("playing fox blueprint animation requested");
         for (link, animations) in animated_fox.iter() {
-            println!("BAR");
+            debug!("BAR");
 
-            // println!("animations {:?}", animations.named_animations);
+            // debug!("animations {:?}", animations.named_animations);
             let (mut animation_player, mut animation_transitions) =
                 animation_players.get_mut(link.0).unwrap();
             let anim_name = "Survey";
@@ -138,15 +138,15 @@ pub fn play_animations(
                 continue;
             };
             let playing_animation = animation_player.animation_mut(playing_animation_index).unwrap();
-            println!("Playing animation {:?}", playing_animation);
+            debug!("Playing animation {:?}", playing_animation);
             playing_animation.set_repeat(RepeatAnimation::Forever);*/
         }
     }
 
     if keycode.just_pressed(KeyCode::KeyP) {
-        println!("playing fox blueprint animation requested");
+        debug!("playing fox blueprint animation requested");
         for (link, animations) in animated_foxes.iter() {
-            // println!("animations {:?}", animations.named_animations);
+            // debug!("animations {:?}", animations.named_animations);
             let (mut animation_player, mut animation_transitions) =
                 animation_players.get_mut(link.0).unwrap();
             let anim_name = "Run";
@@ -167,17 +167,17 @@ pub fn play_animations(
                 continue;
             };
             let playing_animation = animation_player.animation_mut(playing_animation_index).unwrap();
-            println!("Playing animation {:?}", playing_animation);
+            debug!("Playing animation {:?}", playing_animation);
             playing_animation.set_repeat(RepeatAnimation::Forever);*/
         }
-        println!(" ");
+        debug!(" ");
     }
 
     if keycode.just_pressed(KeyCode::KeyO) {
-        println!("playing marker 3 blueprint animation requested");
+        debug!("playing marker 3 blueprint animation requested");
         for (_, _, link, animations) in with_blueprint_and_scene_animations.iter() {
             // This only works for entities that are spawned as part of the level, as scene animations are only there in that case
-            // println!("animations {:?}", animations.named_animations.keys());
+            // debug!("animations {:?}", animations.named_animations.keys());
             let (mut animation_player, mut animation_transitions) =
                 animation_players.get_mut(link.0).unwrap();
             let anim_name = "Walk";
@@ -197,9 +197,9 @@ pub fn play_animations(
     }
 
     if keycode.just_pressed(KeyCode::KeyI) {
-        println!("playing marker 3 scene animation requested");
+        debug!("playing marker 3 scene animation requested");
         for (link, animations, _, _) in with_blueprint_and_scene_animations.iter() {
-            //println!("animations {:?}", animations.named_animations.keys());
+            //debug!("animations {:?}", animations.named_animations.keys());
             let (mut animation_player, mut animation_transitions) =
                 animation_players.get_mut(link.0).unwrap();
             let anim_name = "Blueprint8_move";
@@ -220,7 +220,7 @@ pub fn play_animations(
 
     if keycode.just_pressed(KeyCode::KeyU) {
         for (link, animations) in animated_marker1.iter() {
-            println!("animations {:?}", animations.named_animations);
+            debug!("animations {:?}", animations.named_animations);
             let (mut animation_player, mut animation_transitions) =
                 animation_players.get_mut(link.0).unwrap();
 
@@ -241,7 +241,7 @@ pub fn play_animations(
     }
     if keycode.just_pressed(KeyCode::KeyY) {
         for (link, animations) in animated_marker1.iter() {
-            println!("animations {:?}", animations.named_animations);
+            debug!("animations {:?}", animations.named_animations);
             let (mut animation_player, mut animation_transitions) =
                 animation_players.get_mut(link.0).unwrap();
 
@@ -262,7 +262,7 @@ pub fn play_animations(
     }
     if keycode.just_pressed(KeyCode::KeyT) {
         for (link, animations) in animated_marker2.iter() {
-            println!("animations {:?}", animations.named_animations);
+            debug!("animations {:?}", animations.named_animations);
             let (mut animation_player, mut animation_transitions) =
                 animation_players.get_mut(link.0).unwrap();
 
@@ -287,6 +287,6 @@ pub fn __react_to_animation_markers(
     mut animation_marker_events: EventReader<AnimationMarkerReached>,
 ) {
     for event in animation_marker_events.read() {
-        println!("animation marker event {:?}", event)
+        debug!("animation marker event {:?}", event)
     }
 }

--- a/testing/bevy_example/src/game/mod.rs
+++ b/testing/bevy_example/src/game/mod.rs
@@ -20,7 +20,7 @@ use bevy::{
 use json_writer::to_json_string;
 
 fn start_game(mut next_app_state: ResMut<NextState<AppState>>) {
-    println!("START GAME");
+    debug!("START GAME");
     //next_app_state.set(AppState::AppLoading);
     next_app_state.set(AppState::AppRunning);
 }
@@ -91,7 +91,7 @@ fn validate_export(
             let child_name: String = names
                 .get(child)
                 .map_or(String::from("no_name"), |e| e.to_string()); //|e| e.to_string(), || "no_name".to_string());
-                                                                     //println!("  child {}", child_name);
+                                                                     //debug!("  child {}", child_name);
             let parent = parents.get(child).unwrap();
             let parent_name: String = names
                 .get(parent.get())

--- a/testing/bevy_example/src/hierarchy_debug.rs
+++ b/testing/bevy_example/src/hierarchy_debug.rs
@@ -176,7 +176,7 @@ fn __check_for_component(
             enum_complex, name
         );
         info_lines.push(data);
-        println!("yoho component");
+        debug!("yoho component");
     }
     let mut display = display.single_mut();
     display.sections[0].value = info_lines.join("\n");


### PR DESCRIPTION
There are many places in the code where println! is used for debugging which makes for a lot of noise on the console in some cases. This PR simply bulk replaces println! with debug! so that the messages respect log level. I haven't tried to remove any commented out messages but I changed the macro in those as well.

fixes #245 