### PR TITLE
Reduce dependencies needed for examples by not using default features

### DIFF
--- a/examples/animation/Cargo.toml
+++ b/examples/animation/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bevy = { version = "0.14", features = ["dynamic_linking"] }
+bevy = { version = "0.14", default-features = false, features = ["dynamic_linking"] }
 blenvy = { path = "../../crates/blenvy" }
 rand = "0.8.5"

--- a/examples/blueprints/Cargo.toml
+++ b/examples/blueprints/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bevy = { version = "0.14", features = ["dynamic_linking"] }
+bevy = { version = "0.14", default-features = false, features = ["dynamic_linking"] }
 blenvy = { path = "../../crates/blenvy" }
 rand = "0.8.5"

--- a/examples/components/Cargo.toml
+++ b/examples/components/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bevy = { version = "0.14", features = ["dynamic_linking"] }
+bevy = { version = "0.14", default-features = false, features = ["dynamic_linking"] }
 blenvy = { path = "../../crates/blenvy" }

--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bevy = { version = "0.14", features = ["dynamic_linking"] }
+bevy = { version = "0.14", default-features = false, features = ["dynamic_linking"] }
 blenvy = { path = "../../crates/blenvy" }
 rand = "0.8.5"
 avian3d = "0.1.2"

--- a/examples/save_load/Cargo.toml
+++ b/examples/save_load/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bevy = { version = "0.14", features = ["dynamic_linking"] }
+bevy = { version = "0.14", default-features = false, features = ["dynamic_linking"] }
 blenvy = { path = "../../crates/blenvy" }
 
 serde_json = "1.0.108"

--- a/testing/bevy_example/Cargo.toml
+++ b/testing/bevy_example/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-bevy = { version = "0.14", features = ["dynamic_linking"] }
+bevy = { version = "0.14", default-features = false, features = ["dynamic_linking", "bevy_state", "bevy_ui"] }
 blenvy = { path = "../../crates/blenvy" }
 #bevy_editor_pls = { version = "0.8" }
 rand = "0.8.5"


### PR DESCRIPTION
In particular, this avoids bevy_audio, which has various system library
dependencies.
