### PR TITLE
docs: fix typo (seperate->separate (x10))

### DIFF
--- a/Migration_guide.md
+++ b/Migration_guide.md
@@ -1,7 +1,7 @@
 # Blender add-ons
 
-- gltf_auto_export and bevy_components have been replaced with a single Blenvy add-on for simplicity , I recomend reading the [documentation](./tools/blenvy/README.md)
-    * settings are **not** transfered from the legacy add-ons !
+- gltf_auto_export and bevy_components have been replaced with a single Blenvy add-on for simplicity , I recommend reading the [documentation](./tools/blenvy/README.md)
+    * settings are **not** transferred from the legacy add-ons !
     * first uninstall the old add-ons
     * install Blenvy
     * configure Blenvy (for these , see the Blenvy add-on docs)
@@ -127,7 +127,7 @@ you can now query for this component
 ## Keep your currently spawning blueprint instances hidden until they are ready with the HideUntilReady component
 
 If you want your blueprint instance to be hidden until it is ready, just add this component to the entity.
-This can be particularly usefull in at least two use cases:
+This can be particularly useful in at least two use cases:
 - when spawning levels 
 - when spawning bluprint instances that contain **lights** at runtime: in previous versions I have noticed some very unpleasant "flashing" effect when spawning blueprints with lights,
 this component avoids that issue  

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Crates & tools for adding components from gltf files in the [Bevy](https://bevye
 It enables a [Blender](https://www.blender.org/) (gltf) centric workflow for Bevy, ie defining entites & their components
 inside Blender. Aka "Blender as editor for Bevy"
 
-It also allows you to setup 'blueprints' in Blender by using collections (the recomended way to go most of the time), or directly on single use objects .
+It also allows you to setup 'blueprints' in Blender by using collections (the recommended way to go most of the time), or directly on single use objects .
 
 
 > [!CAUTION]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,7 +15,7 @@ Here is a rundown + rationale behing the changes:
                 * the gltf UI & settings will always keep up with the official releases
                 * less maintenance work
 
-            The only disadvantage is that the standard gltf exporter is a normal exporter, so it generates a 'fake' gltf file that immediatly gets deleted after export, 
+            The only disadvantage is that the standard gltf exporter is a normal exporter, so it generates a 'fake' gltf file that immediately gets deleted after export, 
             so you will need to use the new side panel to set your gltf settings:
              * this is also done to ensure that the gltf settings settings used for auto export are NOT interfering with the ones you might use when exporting gltf files normally
 
@@ -29,7 +29,7 @@ Here is a rundown + rationale behing the changes:
         - improved handling of multi-blend file projects
             Up until now, all export paths where relative ** to the blend file itself** which could lead to issues when working with multiple blend files
             Also for future improvements regarding assets managment, I changed the export paths to be relative to a new "project root" folder which is your *Bevy project's root folder*
-            - the levels/worlds now also got a seperate setting so you can easilly set where to export them too (they are not dumped out into the main export folder anymore), giving you more control over your non blueprint exports
+            - the levels/worlds now also got a separate setting so you can easilly set where to export them too (they are not dumped out into the main export folder anymore), giving you more control over your non blueprint exports
 
     - bevy_components
         Up until now , it was not possible to have multiple components with the same name (ie ) as all the logic was based on short names

--- a/TODO.md
+++ b/TODO.md
@@ -60,7 +60,7 @@ Components:
     - [x] add handling for core::ops::Range<f32> & other ranges
     - [x] fix is_component_valid that is used in blenvy 
     - [x] Hashmap Support
-        - [x] fix parsing of keys's type either on Bevy side (prefered) or on the Blender side 
+        - [x] fix parsing of keys's type either on Bevy side (preferred) or on the Blender side 
         - [x] fix weird issue with missing "0" property when adding new entry in empty hashmap => happens only if the values for the "setter" have never been set
         - [x] handle missing types in registry for keys & values
         - [x] adding a hashmap nukes every existing component ??
@@ -217,7 +217,7 @@ Blender side:
                map asset id => [entity ids]
 
 - [ ] add option to 'split out' meshes from blueprints ? 
-    - [ ] ie considering meshletts etc , it would make sense to keep blueprints seperate from purely mesh gltfs
+    - [ ] ie considering meshletts etc , it would make sense to keep blueprints separate from purely mesh gltfs
 
 - [ ] materials fixes & upgrades
     - [x] materials do not get exported again if the files are missing, until you change a material
@@ -301,7 +301,7 @@ Bevy Side:
     - [x] move sub blueprint handling to blueprints_finalize_instances
 - [x] look into component overriding , it seems broken:
     - [x] blueprint level/ collection level components are now visible in instances in Blender
-    - [x] they do not seem to be transfered to the (instance) entity above:
+    - [x] they do not seem to be transferred to the (instance) entity above:
         could they be on the "empty node" ? 
 
 - [ ] simplify testing example:

--- a/crates/blenvy/README.md
+++ b/crates/blenvy/README.md
@@ -23,7 +23,7 @@ Its main use case is as a backbone for the [```blenvy``` Blender add-on](https:/
 (and any of your custom types & components that you register in Bevy).
 - adds the ability to easilly **save** and **load** your game worlds for [Bevy](https://bevyengine.org/) .
 
-* leverages blueprints & seperation between 
+* leverages blueprints & separation between 
     * **dynamic** entities : entities that can change during the lifetime of your app/game
     * **static** entities : entities that do NOT change (typically, a part of your levels/ environements)
 * and allows allow for :
@@ -33,7 +33,7 @@ Its main use case is as a backbone for the [```blenvy``` Blender add-on](https:/
     * ability to specify **which resources** to save or to exclude
     * small(er) save files (only a portion of the entities is saved)
 
-Particularly useful when using [Blender](https://www.blender.org/) as an editor for the [Bevy](https://bevyengine.org/) game engine, combined with the [Blender plugin](https://github.com/kaosat-dev/Blenvy/tree/main/tools/blenvy) that does a lot of the work for you (including spliting generating seperate gltf files for your static vs dynamic assets)
+Particularly useful when using [Blender](https://www.blender.org/) as an editor for the [Bevy](https://bevyengine.org/) game engine, combined with the [Blender plugin](https://github.com/kaosat-dev/Blenvy/tree/main/tools/blenvy) that does a lot of the work for you (including spliting generating separate gltf files for your static vs dynamic assets)
 
 ## Usage
 
@@ -203,7 +203,7 @@ There is also a ```BluePrintBundle``` for convenience , which just has
 - this crate also provides a special optional ```GameWorldTag``` component: this is useful when you want to keep all your spawned entities inside a root entity
 
 You can use it in your queries to add your entities as children of this "world"
-This way all your levels, your dynamic entities etc, are kept seperated from UI nodes & other entities that are not relevant to the game world
+This way all your levels, your dynamic entities etc, are kept separated from UI nodes & other entities that are not relevant to the game world
 
 > Note: you should only have a SINGLE entity tagged with that component !
 

--- a/examples/demo/README.md
+++ b/examples/demo/README.md
@@ -1,6 +1,6 @@
 # Multiple levels from multiple blend files example/demo
 
-This example showcases multiple levels, each created from a seperate Blend file , with all assets stored in the (common file)[./art/common.blend]
+This example showcases multiple levels, each created from a separate Blend file , with all assets stored in the (common file)[./art/common.blend]
 It using triggers to transition to another level.
 It currently has NO state persistence between levels.
 You can press "D" to toggle the physics debug view.

--- a/tools/blenvy/README-components.md
+++ b/tools/blenvy/README-components.md
@@ -34,7 +34,7 @@ The second tab in the settings contains the component settings:
   * hashmaps
   * etc !
 
-![suported types](./docs/components_suported_types.png)
+![supported types](./docs/components_suported_types.png)
 
 ## Supported items for components
 
@@ -184,6 +184,6 @@ of your Bevy components you get a nicely packed custom_property
 - changing the values of a component in the UI  will automatically update the value of the underlying entry in the ```bevy_components``` custom property
 - different item types in Blender result in different types of GltfExtra components in Bevy (this all happens under the hood):
   - objects : GltfExtras
-  - collections/ blueprints: SceneGltfExtras (as the Blueprints get exported as seperate scenes)
+  - collections/ blueprints: SceneGltfExtras (as the Blueprints get exported as separate scenes)
   - meshes: MeshGltfExtras
   - materials: MaterialGltfExtras

--- a/tools/blenvy/README-export.md
+++ b/tools/blenvy/README-export.md
@@ -48,8 +48,8 @@ you can turn this off
 
 select which option you want to use to deal with collection instances (aka combine mode) (both inside blueprint collections & main collections)
 
-  * split (default, highly recomended) : the addon will 'split out' any nested collections/ blueprints & export them
-  * embed: choose this option if you want to keep everything inside a gltf file (less efficient, not recomended)
+  * split (default, highly recommended) : the addon will 'split out' any nested collections/ blueprints & export them
+  * embed: choose this option if you want to keep everything inside a gltf file (less efficient, not recommended)
   * embedExternal: this will embed ONLY collection instances whose collections have not been found inside the current blend file
 
   These options can also be **overridden** on a per collection instance basis: (if you want to split out most collection instances, but keep a few specific ones embeded
@@ -67,7 +67,7 @@ For levels scenes only, toggle this to generate 2 files per level:
   - one with all dynamic data: collections or instances marked as dynamic (aka saveable)
   - one with all static data: anything else that is NOT marked as dynamic, the file name will have the suffix **_dynamic**
 
-  Ie if you add a **Dynamic** custom/ component to either your collection instances or your blueprint, you get a clean seperation between 
+  Ie if you add a **Dynamic** custom/ component to either your collection instances or your blueprint, you get a clean separation between 
 
   - your static level data (anything that will never change during the lifetime of your Bevy app)
   - your dynamic objects (anything that will change during the lifetime of your Bevy app, that can be saved & reloaded in save files for example)

--- a/tools/blenvy/README-tech.md
+++ b/tools/blenvy/README-tech.md
@@ -5,7 +5,7 @@ You can enable this option to automatically replace all the **collection instanc
     * will be replaced with empties (this will not be visible to you)
     * those empties will have additional custom properties / components : ```BlueprintInfo``` & ```SpawnBlueprint```
     * your level scene/ level will be exported to a much more trimmed down gltf file (see next point)
-    * all the original collections (that you used to create the instances) will be exported as **seperate gltf files** into the "library" folder
+    * all the original collections (that you used to create the instances) will be exported as **separate gltf files** into the "library" folder
 
 - this means you will have 
     * one small main gltf file (your level/world)

--- a/tools/blenvy/README.md
+++ b/tools/blenvy/README.md
@@ -69,8 +69,8 @@ you **need** to tell Blenvy
 
 Blenvy is opinionated ! 
 
-  - keep you art/sources (usually not delivered with your game) seperate from your game assets
-  - keep your blueprints/levels/materials gltf files seperate
+  - keep you art/sources (usually not delivered with your game) separate from your game assets
+  - keep your blueprints/levels/materials gltf files separate
 
 ##### Root Folder (default: ../)
 
@@ -103,11 +103,11 @@ Blenvy is opinionated !
 
 #### Recomended folder structure
 
-![recomended folder structure](./docs/blenvy_recommended_folder_structure.png)
+![recommended folder structure](./docs/blenvy_recommended_folder_structure.png)
 
-![recomended folder structure art](./docs/blenvy_recommended_folder_structure_art.png)
+![recommended folder structure art](./docs/blenvy_recommended_folder_structure_art.png)
 
-![recomended folder structure assets](./docs/blenvy_recommended_folder_structure_assets.png)
+![recommended folder structure assets](./docs/blenvy_recommended_folder_structure_assets.png)
 
 
 ##### Components & export settings:
@@ -118,7 +118,7 @@ Blenvy is opinionated !
 
 ### Multiple blend file workflow
 
-If you want to use multiple blend files (recomended if your project starts to grow even a bit), use Blender's asset library etc, we got you coverred too !
+If you want to use multiple blend files (recommended if your project starts to grow even a bit), use Blender's asset library etc, we got you coverred too !
 There are only a few things to keep in mind 
 
 #### Assets/library/blueprints files
@@ -127,11 +127,11 @@ There are only a few things to keep in mind
 - choose "split" for the combine mode (as you want your gltf blueprints to be saved for external use)
 - do your Blender things as normal
 - anytime you save your file, it will automatically export any relevant collections/blueprints
-- (optional) activate the **material library** option, so you only have one set of material per asset library (recomended)
+- (optional) activate the **material library** option, so you only have one set of material per asset library (recommended)
 
 #### Level/world files
 - mark your level scenes as specified above ( personally I recommended **NOT** specifying a **library** scene in this case to keep things tidy, but that is up to you)
-- configure your asset libraries as you would usually do, I recomend using the "link" mode so that any changes to asset files are reflected correctly
+- configure your asset libraries as you would usually do, I recommend using the "link" mode so that any changes to asset files are reflected correctly
 - drag & drop any assets from the blueprints library (as you would normally do in Blender as well)
 - choose "split" for the combine mode (as you want your gltf blueprints to be external usually & use the gltf files generated from your assets library)
 - do your Blender things as normal
@@ -159,13 +159,13 @@ Take a look at the [relevant](../../examples/demo/) example for more [details](.
 - for a detailed overview of blueprints please see [here](./README-blueprints.md)
 
 > [!TIP]
-> you can right click on a Blueprint instance in your level scenes or press SHIFT  + F to edit a Blueprint in a seperate temprary scene !
+> you can right click on a Blueprint instance in your level scenes or press SHIFT  + F to edit a Blueprint in a separate temprary scene !
 > you can right click or press SHIFT + F to create a new empty Blueprint and an instance of it from your main scenes
 > right click again & select the option to stop editing it, or 
 
 ## Development 
 
-- I highly recomend (if you are using vscode like me) to use 
+- I highly recommend (if you are using vscode like me) to use 
 [this](https://marketplace.visualstudio.com/items?itemName=JacquesLucke.blender-development) excellent extension , works easilly and fast , even for the latest 
 versions of Blender (v4.0 as of this writing)
 - this [article](https://polynook.com/learn/set-up-blender-addon-development-environment-in-windows) might also help out 

--- a/tools/blenvy/old.md
+++ b/tools/blenvy/old.md
@@ -61,7 +61,7 @@ This issue has been resolved in v0.9.
 
 #### Collection instances & Nested blueprints
 
-To maximise reuse of meshes/components etc, you can also nest ***collections instances*** inside collections (as normally in Blender), but also export each nested Blueprint as a seperate blueprints.
+To maximise reuse of meshes/components etc, you can also nest ***collections instances*** inside collections (as normally in Blender), but also export each nested Blueprint as a separate blueprints.
 
 > Don't forget to choose the relevant option in the exporter settings (aka **"split"**)
 
@@ -130,7 +130,7 @@ generate the corresponding component for you:
 ### Existing components & custom properties
 
 * If you already have components defined manualy in Blender inside **custom properties** you will need to define them again using the UI!
-* avoid mixing & matching: if you change the values of **custom properties** that also have a component, the custom property will be **overriden** every time
+* avoid mixing & matching: if you change the values of **custom properties** that also have a component, the custom property will be **overridden** every time
 you change the component's value
 * you can of course still use non component custom properties as always, this add-on will only impact those that have corresponding Bevy components
 


### PR DESCRIPTION
## Summary
Fixes spelling/typo issues found in this project's documentation.

**Details:** Fix documentation typos: seperate->separate (x10); prefered->preferred (x1); transfered->transferred (x2); recomended->recommended (x8); recomend->recommend (x3); usefull->useful (x1); immediatly->immediately (x1); seperated->separated (x1)

**Files:**
- `TODO.md`
- `README.md`
- `Migration_guide.md`
- `RELEASE_NOTES.md`
- `examples/demo/README.md`
- `crates/blenvy/README.md`
- `tools/blenvy/README-components.md`
- `tools/blenvy/README.md`
- `tools/blenvy/old.md`
- `tools/blenvy/README-tech.md`
- `tools/blenvy/README-export.md`

Documentation-only; no functional code changes.
